### PR TITLE
Fix to keep right indent https://github.com/webmin/webmin/commit/bf06…

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -8012,6 +8012,7 @@ else {
 	&save_domain($d);
 
 	# Update other services using the cert
+	undef(@dovecot::get_config_cache);
 	&update_all_domain_service_ssl_certs($d, \@beforecerts);
 
 	&break_invalid_ssl_linkages($d);


### PR DESCRIPTION
…2d8228eb635b847a8d7cc422319a748d6a21

It seems not very safe to write to a file like this (dovecot.conf). I don't know what we gain in the end by doing such caching but the problem is, unless `undef(@dovecot::get_config_cache);` is called, the file structure is strictly expected it to be the same (upon initial start of the script and its end - which can be a pretty long time). For instance, if I open a file (dovecot.conf) using a text editor and edit it between, when the inital SSL records are created and before LE request finishes with success, the file will end up broken, because we expect directives on specific lines. I don't wanna say caching is bad. I just don't believe that it has any significant impact on performance but apparently quite a bit of potential issues. I assume using Webmin it will not be possible to write to a file, as it's locked but there are multiple of other processes that could write to a file. I know that doing caching in general is a good and a right thing to do. It's just that there is almost no gain, as reading and parsing 1kb - 10kb file mustn't affect performance in a way, compared to a level of rased complexity (renumbering lines and etc). I think we should keep it as it is for now (with this change applied), but I would prefer to use caching only, if we can open and write a file pretty quickly. If the process takes 30-60 seconds or more, it's just not safe to use caching this way.